### PR TITLE
Enable header logo scroll-to-top behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- Header -->
   <header class="fixed top-0 left-0 right-0 bg-white shadow z-50">
     <div class="container mx-auto flex justify-center items-center p-4">
-      <img src="assets/Name-logo.png" alt="Linden Street LLC" class="h-12">
+      <button id="scroll-to-top" class="focus:outline-none bg-transparent border-0 p-0">
+        <img src="assets/Name-logo.png" alt="Linden Street LLC" class="h-12">
+      </button>
     </div>
   </header>
 

--- a/js/script.js
+++ b/js/script.js
@@ -78,4 +78,11 @@ document.addEventListener('DOMContentLoaded', () => {
     highlightCard(); // initial
     setInterval(highlightCard, 3000); // every 3s
   }
+
+  const scrollBtn = document.getElementById('scroll-to-top');
+  if (scrollBtn) {
+    scrollBtn.addEventListener('click', () =>
+      window.scrollTo({ top: 0, behavior: 'smooth' })
+    );
+  }
 });


### PR DESCRIPTION
## Summary
- wrap header logo in button and remove default styling
- add click handler to smoothly scroll page to top

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_b_688fbf2f6a04832cbd95da2d7c45862a