### PR TITLE
Redirect contact form to top of page with confirmation

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </button>
     </div>
   </header>
+  <div id="top-success-message" class="hidden text-center bg-green-100 text-green-700 py-2">
+    ✅ Thank you! Your message has been sent.
+  </div>
 
   <!-- Hero -->
   <section class="relative h-screen flex items-center justify-center text-white overflow-hidden">

--- a/js/script.js
+++ b/js/script.js
@@ -1,11 +1,20 @@
-// Contact Form success message
+// Contact Form redirect after submission
 function formSubmitted() {
   setTimeout(() => {
-    document.getElementById('success-message').classList.remove('hidden');
+    window.location.replace('/?form_submitted=true');
   }, 500);
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('form_submitted') === 'true') {
+    window.scrollTo(0, 0);
+    const topMessage = document.getElementById('top-success-message');
+    if (topMessage) topMessage.classList.remove('hidden');
+    const successMessage = document.getElementById('success-message');
+    if (successMessage) successMessage.classList.remove('hidden');
+  }
+
   // ===== Counter Donut =====
   const counterSection = document.querySelector('#counter-value');
   const donutProgress = document.getElementById('donut-progress');


### PR DESCRIPTION
## Summary
- Redirect contact form submissions to the site root with a `form_submitted=true` flag.
- Scroll to the top and display a success banner when the query parameter is present.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e9832a0948333a1cc05576fcfd564