### PR TITLE
Redirect contact form submissions to top of page

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       action="https://docs.google.com/forms/d/e/1FAIpQLSeY0xZw-JpdOGkBctQfC5vFPZHe6qxVD-8av5gD8fa3HfIKIA/formResponse" 
       method="POST" 
       target="hidden_iframe" 
-      onsubmit="formSubmitted()" 
+      onsubmit="formSubmitted(event)" 
       class="max-w-lg mx-auto bg-white shadow p-6 rounded">
       <input type="text" name="entry.295846301" placeholder="Your Name" class="w-full border p-2 mb-4 rounded" required>
       <input type="email" name="entry.1167689731" placeholder="Your Email" class="w-full border p-2 mb-4 rounded" required>

--- a/js/script.js
+++ b/js/script.js
@@ -1,8 +1,21 @@
 // Contact Form redirect after submission
-function formSubmitted() {
-  setTimeout(() => {
-    window.location.href = 'https://www.lindenstreetllc.com/?form_submitted=true';
-  }, 500);
+function formSubmitted(event) {
+  event.preventDefault();
+
+  const redirectUrl = 'https://www.lindenstreetllc.com/?form_submitted=true';
+  const iframe = document.getElementById('hidden_iframe');
+
+  if (iframe) {
+    iframe.addEventListener(
+      'load',
+      () => {
+        window.location.href = redirectUrl;
+      },
+      { once: true }
+    );
+  }
+
+  event.target.submit();
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- Ensure contact form submits via hidden iframe and redirects to site root with `form_submitted` flag once submission completes
- Hook redirect logic into `load` event and expose form-submitted messages at page top

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e9c49a01083338b2a289cdb1d4ff8